### PR TITLE
Add prototype declaration for gst_v4l2_object_streamoff

### DIFF
--- a/sys/v4l2/gstv4l2object.h
+++ b/sys/v4l2/gstv4l2object.h
@@ -323,6 +323,7 @@ GstStructure * gst_v4l2_object_v4l2fourcc_to_structure (guint32 fourcc);
 
 /* crop / compose */
 gboolean     gst_v4l2_object_set_crop (GstV4l2Object * obj, struct v4l2_rect *result);
+gboolean     gst_v4l2_object_streamoff (GstV4l2Object * v4l2object);
 
 /* TODO Move to proper namespace */
 /* open/close the device */


### PR DESCRIPTION
Fixes build with latest compilers e.g. clang-16

../git/sys/v4l2/gstv4l2videodec.c:354:10: error: call to undeclared function 'gst_v4l2_object_streamoff'; ISO C99 and later do not support implicit function declarations [ -Wimplicit-function-declaration]
    if (!gst_v4l2_object_streamoff (self->v4l2capture))
         ^